### PR TITLE
Add quotes to build messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,33 +174,4 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>build-with-jdk-6</id>
-            <activation>
-                <jdk>[1.7,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>1.6</version>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
+++ b/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
@@ -117,15 +117,19 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
     }
 
     protected String buildNotificationMessage(MavenExecutionResult result) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("'");
         if (shouldBuildShortDescription(result)) {
-            return buildShortDescription(result);
+            builder.append(buildShortDescription(result));
+        } else {
+            builder.append(buildFullDescription(result));
         }
-        return buildFullDescription(result);
+        builder.append("'");
+        return builder.toString();
     }
 
     private String buildFullDescription(MavenExecutionResult result) {
         StringBuilder builder = new StringBuilder();
-        builder.append("'");
         for (MavenProject project : result.getTopologicallySortedProjects()) {
             BuildSummary buildSummary = result.getBuildSummary(project);
             Status status = Status.of(buildSummary);
@@ -133,20 +137,19 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
             builder.append(": ");
             builder.append(status.message());
             if (status != Status.SKIPPED) {
-                builder.append(" [");
+                builder.append(" ");
                 builder.append(TimeUnit.MILLISECONDS.toSeconds(buildSummary.getTime()));
-                builder.append("s] ");
+                builder.append("s ");
             }
             builder.append(LINE_BREAK);
         }
-        builder.append("'");
         return builder.toString();
     }
 
     private String buildShortDescription(MavenExecutionResult result) {
         switch (getBuildStatus(result)) {
             case SUCCESS:
-                return "Built in: " + elapsedTime() + " second(s).";
+                return "Built in: " + elapsedTime() + " seconds.";
             case FAILURE:
                 return "Build Failed.";
             default:
@@ -170,7 +173,7 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
     }
 
     private String buildFullTitle(MavenExecutionResult result) {
-        return result.getProject().getName() + " [" + elapsedTime() + "s]";
+        return result.getProject().getName() + " ... " + elapsedTime() + "s";
     }
 
     private String buildShortTitle(MavenExecutionResult result) {

--- a/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
+++ b/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
@@ -125,6 +125,7 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
 
     private String buildFullDescription(MavenExecutionResult result) {
         StringBuilder builder = new StringBuilder();
+        builder.append("'");
         for (MavenProject project : result.getTopologicallySortedProjects()) {
             BuildSummary buildSummary = result.getBuildSummary(project);
             Status status = Status.of(buildSummary);
@@ -138,6 +139,7 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
             }
             builder.append(LINE_BREAK);
         }
+        builder.append("'");
         return builder.toString();
     }
 

--- a/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierTest.groovy
@@ -76,7 +76,7 @@ class SendNotificationNotifierTest {
 
         verify(notifier).send(notification.capture())
         assertThat notification.value.title() isEqualTo 'project-multimodule [3s]'
-        assertThat notification.value.message() isEqualTo String.format('module-1: Success [1s] %nmodule-2: Success [2s] %n')
+        assertThat notification.value.message() isEqualTo String.format("'module-1: Success [1s] %nmodule-2: Success [2s] %n'")
     }
 
     @Test

--- a/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierTest.groovy
@@ -64,7 +64,7 @@ class SendNotificationNotifierTest {
         underTest.onEvent(anEvent('title'))
 
         verify(notifier).send(notification.capture())
-        assertThat notification.value.title() isEqualTo 'title [2s]'
+        assertThat notification.value.title() isEqualTo 'title ... 2s'
     }
 
     @Test
@@ -75,8 +75,8 @@ class SendNotificationNotifierTest {
                 aModule('module-1', SECONDS.toMillis(1L)), aModule('module-2', SECONDS.toMillis(2L))))
 
         verify(notifier).send(notification.capture())
-        assertThat notification.value.title() isEqualTo 'project-multimodule [3s]'
-        assertThat notification.value.message() isEqualTo String.format("'module-1: Success [1s] %nmodule-2: Success [2s] %n'")
+        assertThat notification.value.title() isEqualTo 'project-multimodule ... 3s'
+        assertThat notification.value.message() isEqualTo String.format("'module-1: Success 1s %nmodule-2: Success 2s %n'")
     }
 
     @Test
@@ -87,7 +87,7 @@ class SendNotificationNotifierTest {
 
         verify(notifier).send(notification.capture())
         assertThat notification.value.title() isEqualTo 'title'
-        assertThat notification.value.message() isEqualTo 'Built in: 1 second(s).'
+        assertThat notification.value.message() isEqualTo "'Built in: 1 seconds.'"
     }
 
     @Test
@@ -98,7 +98,7 @@ class SendNotificationNotifierTest {
 
         verify(notifier).send(notification.capture())
         assertThat notification.value.title() isEqualTo 'project'
-        assertThat notification.value.message() isEqualTo 'Build Failed.'
+        assertThat notification.value.message() isEqualTo "'Build Failed.'"
     }
 
     @Test
@@ -110,7 +110,7 @@ class SendNotificationNotifierTest {
 
         verify(notifier).send(notification.capture())
         assertThat notification.value.title() isEqualTo 'title'
-        assertThat notification.value.message() isEqualTo 'Built in: 1 second(s).'
+        assertThat notification.value.message() isEqualTo "'Built in: 1 seconds.'"
     }
 
     @Test


### PR DESCRIPTION
The following changes were required in order to build maven-notifier with Java 8, and to utilize the resulting Jar file Maven extension on Linux. The notify-send command really needs the message body to be quoted, or it is misinterpreted by the shell. This code compiles and has been tested in my own working environment.