### PR TITLE
Do not close notifier with mvnd

### DIFF
--- a/src/main/java/fr/jcgay/maven/notifier/AbstractCustomEventSpy.java
+++ b/src/main/java/fr/jcgay/maven/notifier/AbstractCustomEventSpy.java
@@ -36,7 +36,7 @@ public abstract class AbstractCustomEventSpy implements Notifier {
 
     @Override
     public void close() {
-        // do nothing
+        stopwatch.reset();
     }
 
     @Override

--- a/src/main/java/fr/jcgay/maven/notifier/Mvnd.java
+++ b/src/main/java/fr/jcgay/maven/notifier/Mvnd.java
@@ -1,0 +1,12 @@
+package fr.jcgay.maven.notifier;
+
+public class Mvnd {
+
+    private Mvnd() {
+        // Hide me, I'm famous! 😎
+    }
+
+    public static boolean isRunningWithMvnd() {
+        return System.getProperties().keySet().stream().anyMatch(key -> key.toString().startsWith("mvnd."));
+    }
+}

--- a/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
+++ b/src/main/java/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifier.java
@@ -3,6 +3,7 @@ package fr.jcgay.maven.notifier.sendnotification;
 import com.google.common.annotations.VisibleForTesting;
 import fr.jcgay.maven.notifier.AbstractCustomEventSpy;
 import fr.jcgay.maven.notifier.Configuration;
+import fr.jcgay.maven.notifier.Mvnd;
 import fr.jcgay.maven.notifier.Notifier;
 import fr.jcgay.maven.notifier.Status;
 import fr.jcgay.notification.Application;
@@ -28,21 +29,20 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
     private static final Icon ICON = Icon.create(resource("maven.png"), "maven");
     private static final String LINE_BREAK = System.getProperty("line.separator");
 
+    private final boolean isDaemon;
+
     private SendNotification sendNotification;
     private fr.jcgay.notification.Notifier notifier;
 
     public SendNotificationNotifier() {
         this.sendNotification = new SendNotification();
+        this.isDaemon = Mvnd.isRunningWithMvnd();
     }
 
     @VisibleForTesting
-    SendNotificationNotifier(SendNotification sendNotification) {
-        this.sendNotification = sendNotification;
-    }
-
-    @VisibleForTesting
-    SendNotificationNotifier(fr.jcgay.notification.Notifier notifier) {
+    SendNotificationNotifier(fr.jcgay.notification.Notifier notifier, boolean isDaemon) {
         this.notifier = notifier;
+        this.isDaemon = isDaemon;
     }
 
     @Override
@@ -58,7 +58,9 @@ public class SendNotificationNotifier extends AbstractCustomEventSpy {
     @Override
     public void close() {
         super.close();
-        notifier.close();
+        if (!isDaemon) {
+            notifier.close();
+        }
     }
 
     @Override

--- a/src/test/groovy/fr/jcgay/maven/notifier/AbstractCustomEventSpyTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/AbstractCustomEventSpyTest.groovy
@@ -44,11 +44,22 @@ class AbstractCustomEventSpyTest {
     }
 
     @Test
-    void 'should stop timer when closing event spy'() throws Exception {
+    void 'should stop timer when listening to an event'() throws Exception {
 
         eventSpy.init({ Collections.emptyMap() })
         eventSpy.onEvent(new DefaultMavenExecutionResult())
 
+        assertThat stopwatch.isRunning() isFalse()
         assertThat stopwatch.elapsed(SECONDS) isEqualTo 2L
+    }
+
+    @Test
+    void 'should reset time when closing event spy'() {
+
+        eventSpy.init({ Collections.emptyMap() })
+        eventSpy.close()
+
+        assertThat stopwatch.isRunning() isFalse()
+        assertThat stopwatch.elapsed(SECONDS) isEqualTo 0L
     }
 }

--- a/src/test/groovy/fr/jcgay/maven/notifier/Fixtures.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/Fixtures.groovy
@@ -1,0 +1,71 @@
+package fr.jcgay.maven.notifier
+
+import org.apache.maven.execution.BuildSuccess
+import org.apache.maven.execution.MavenExecutionResult
+import org.apache.maven.project.MavenProject
+
+import static org.mockito.AdditionalAnswers.returnsElementsOf
+import static org.mockito.ArgumentMatchers.isA
+import static org.mockito.Mockito.*
+
+class Fixtures {
+
+    static MavenExecutionResult aSuccessfulProject() {
+        def project = aProjectWithOneModule('project')
+        when project.hasExceptions() thenReturn false
+        project
+    }
+
+    static MavenExecutionResult aFailingProject() {
+        def project = aProjectWithOneModule('project')
+        when project.hasExceptions() thenReturn true
+        project
+    }
+
+    static MavenExecutionResult aProjectWithMultipleModule(String projectName) {
+        def result = anEvent(projectName)
+        when result.getTopologicallySortedProjects().size() thenReturn 4
+        result
+    }
+
+    static MavenExecutionResult aProjectWithMultipleModule(String projectName, Project... projects) {
+        def result = anEvent(projectName)
+        when result.getTopologicallySortedProjects() thenReturn projects.collect { Project project -> mavenProject(project.name) }
+        when result.getBuildSummary(isA(MavenProject)) thenAnswer returnsElementsOf(projects.collect { Project project -> new BuildSuccess(mavenProject(project.name), project.time) })
+        result
+    }
+
+    static MavenExecutionResult aProjectWithOneModule(String projectName) {
+        def result = anEvent(projectName)
+        when result.getTopologicallySortedProjects().size() thenReturn 1
+        result
+    }
+
+    static MavenExecutionResult anEvent(String projectName) {
+        def result = mock(MavenExecutionResult, RETURNS_DEEP_STUBS)
+        when result.project.name thenReturn projectName
+        result
+    }
+
+    static URL resource(String resource) {
+        Thread.currentThread().getContextClassLoader().getResource(resource)
+    }
+
+    static Project aModule(String name, long time) {
+        def project = new Project()
+        project.name = name
+        project.time = time
+        project
+    }
+
+    static MavenProject mavenProject(String name) {
+        def project = new MavenProject()
+        project.name = name
+        project
+    }
+
+    static class Project {
+        String name
+        long time
+    }
+}

--- a/src/test/groovy/fr/jcgay/maven/notifier/MvndTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/MvndTest.groovy
@@ -1,0 +1,32 @@
+package fr.jcgay.maven.notifier
+
+
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assumptions.assumeThat
+
+class MvndTest {
+
+    private static final String MVND_PROP = "mvnd.something"
+
+    @BeforeMethod
+    void setUp() {
+        System.clearProperty(MVND_PROP)
+    }
+
+    @Test
+    void 'return true when mvnd property is present'() {
+        System.setProperty(MVND_PROP, "ok")
+
+        assertThat(Mvnd.isRunningWithMvnd()).isTrue()
+    }
+
+    @Test
+    void 'return false when no mvnd property is present'() {
+        assumeThat(System.getProperties()).isNotEmpty()
+
+        assertThat(Mvnd.isRunningWithMvnd()).isFalse()
+    }
+}

--- a/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierRunningWithMvndTest.groovy
+++ b/src/test/groovy/fr/jcgay/maven/notifier/sendnotification/SendNotificationNotifierRunningWithMvndTest.groovy
@@ -1,0 +1,65 @@
+package fr.jcgay.maven.notifier.sendnotification
+
+import fr.jcgay.maven.notifier.Configuration
+import fr.jcgay.maven.notifier.ConfigurationParser
+import fr.jcgay.notification.Notification
+import fr.jcgay.notification.Notifier
+import groovy.transform.CompileStatic
+import org.codehaus.plexus.logging.Logger
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static fr.jcgay.maven.notifier.Fixtures.anEvent
+import static fr.jcgay.maven.notifier.KnownElapsedTimeTicker.aStartedStopwatchWithElapsedTime
+import static java.util.concurrent.TimeUnit.SECONDS
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.Mockito.*
+import static org.mockito.MockitoAnnotations.initMocks
+
+@CompileStatic
+class SendNotificationNotifierRunningWithMvndTest {
+
+    @Mock
+    private Notifier notifier
+
+    @Captor
+    private ArgumentCaptor<Notification> notification
+
+    private Configuration configuration
+
+    private SendNotificationNotifier underTest
+
+    @BeforeMethod
+    void setUp() throws Exception {
+        initMocks this
+
+        configuration = new Configuration()
+
+        def parser = mock ConfigurationParser
+        when parser.get() thenReturn configuration
+
+        underTest = new SendNotificationNotifier(notifier, true)
+        underTest.configuration = parser
+        underTest.logger = mock(Logger)
+    }
+
+    @Test
+    void 'should not call close when exiting notifier'() {
+        underTest.close()
+
+        verify(notifier, never()).close()
+    }
+
+    @Test
+    void 'should send notification when an event is triggered'() {
+        underTest.stopwatch = aStartedStopwatchWithElapsedTime(SECONDS.toNanos(2L))
+
+        underTest.onEvent(anEvent('title'))
+
+        verify(notifier).send(notification.capture())
+        assertThat notification.value.title() isEqualTo 'title [2s]'
+    }
+}


### PR DESCRIPTION
https://github.com/mvndaemon/mvnd is a Gradle like daemon for Maven.

When used with maven-notifer, a notification is only displayed during the first build
on a fresh daemon.
For succeeding builds, the notification will not be displayed.

It comes from the fact that SendNotificationNotifier will never be re-instantiated after the 'close'
method has been called.
In a standard Maven lifecycle everything is startup for each build as a new JVM is stared.
But this is not the case with mvnd.

Notifiers should not rely on state given by the constructor (meaning re-initializing everything in 'init') or do not 'close' at all and let resources being cleaned up when the daemon stop.

This commit does not call 'close' anymore when we detect that a build is run with mvnd.

Fixes #108